### PR TITLE
Fix Send CAN Commands

### DIFF
--- a/Example/openxcframework/SendCanViewController.swift
+++ b/Example/openxcframework/SendCanViewController.swift
@@ -229,14 +229,9 @@ class SendCanViewController: UIViewController, UITextFieldDelegate {
                 lastReq.text = "Invalid command : need a payload"
                 return
             }
-            if Int(payldtrim,radix:16) as NSInteger? == nil {  //!=nil   Int(payldtrim,radix:16) as NSInteger?
-                cmd.data = payloadhex! as NSString                //dataField.text as String?
-                if (cmd.data.length % 2) == 1 {
-                    cmd.data = "0" + payloadhex as NSString      //dataField.text! as NSString
-                }
-            } else {
-                lastReq.text = "Invalid command : payload should be hex number (with no leading 0x)"
-                return
+            cmd.data = payloadhex! as NSString                //dataField.text as String?
+            if (cmd.data.length % 2) == 1 {
+                cmd.data = "0" + payloadhex as NSString      //dataField.text! as NSString
             }
         } else {
             lastReq.text = "Invalid command : need a payload"

--- a/openxcframework/VehicleManager.swift
+++ b/openxcframework/VehicleManager.swift
@@ -737,9 +737,10 @@ open class VehicleManager: NSObject {
     
     
     // build the command json
-    let cmd = "{\"bus\":\(cmd.bus),\"id\":\(cmd.id),\"data\":\"\(cmd.data)\"}"
+    let cmdjson : NSMutableString = ""
+    cmdjson.append("{\"bus\":\(cmd.bus),\"id\":\(cmd.id),\"data\":\"\(cmd.data)\"}\0")
     // append to tx buffer
-    BLETxDataBuffer.add(cmd.data(using: String.Encoding.utf8, allowLossyConversion: false)!)
+    BLETxDataBuffer.add(cmdjson.data(using: String.Encoding.utf8.rawValue, allowLossyConversion: false)!)
     
     // trigger a BLE data send
     BluetoothManager.sharedInstance.BLESendFunction()


### PR DESCRIPTION
### Changes
- Fixed sending CAN messages to C5 BLE
    - Both 7 and 8 byte payloads work

### Notes
The issue earlier with 8 byte payloads was that when using `radix` to convert a string to a hex, the integer that resulted was greater than the max supported integer. Thus it would always return `nil` because an integer couldn't be as big as the hex value we were trying. Also I assume it is safe to delete this as now each box prevents entering non-hex values. The code that was removed in this PR was just the code to check if the string is truly a hex value.

| Variable | Value |
| - | - |
| Max Int | 9223372036854775807 |
| 7 Byte | 71494644085555200 |
| 8 Byte | 18302628885902131000 |

As for the sending of messages, CAN messages are now built and sent similar to diagnostic messages. It also doesn't seem to work if the JSON string doesn't have a null terminating character at the end - `\0`.